### PR TITLE
fix encoding error #1

### DIFF
--- a/ja_cvu_normalizer/reader.py
+++ b/ja_cvu_normalizer/reader.py
@@ -42,7 +42,7 @@ def to_char(unicodes: list):
 
 def cvuj_reader(filepath):
     mapping_table = dict()
-    with open(filepath) as f:
+    with open(filepath, encoding='utf-8') as f:
         for row in csv.reader(decomment(f), delimiter="\t"):
             mapper = (to_char([row[0]]), to_char(row[1].split(" ")))
             mapping_table[mapper[0]] = mapper[1]


### PR DESCRIPTION
fix #1 
`resource/ISO-2022-JP.txt`のエンコードがUTF-8のため、45行目のopen()にencoding='utf-8'を指定しました。
Windowsでのエラーはこの修正で解決しました。

Because the encoding of `resource/ISO-2022-JP.txt` is UTF-8, I specified encoding='utf-8' in open() at line 45.
The error on Windows has been resolved with this fix.